### PR TITLE
adds task to run app with remote debugging

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,6 +39,5 @@ module.exports = function(grunt) {
     grunt.registerTask('build', ['nodewebkit']);
     grunt.registerTask('server', ['browserSync']);
     grunt.registerTask('run', ['shell:runApp']);
-    grunt.registerTask('debug', ['shell:runAppDebug'])
-
+    grunt.registerTask('remote-debug', ['shell:runAppDebug']);
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,11 +1,11 @@
-module.exports = function(grunt) { 
+module.exports = function(grunt) {
 
     grunt.initConfig({
 
         nodewebkit: {
             options: {
                 platforms: ['osx'],
-                buildDir: './build', 
+                buildDir: './build',
                 macIcns: './app/icon/logo.icns'
             },
             src: ['./app/**/*']
@@ -25,8 +25,12 @@ module.exports = function(grunt) {
         shell: {
             runApp: {
                 command: '/Applications/node-webkit.app/Contents/MacOS/node-webkit ./app'
+            },
+
+            runAppDebug: {
+                command: '/Applications/node-webkit.app/Contents/MacOS/node-webkit ./app --remote-debugging-port=9222'
             }
-        }        
+        }
 
     });
 
@@ -35,5 +39,6 @@ module.exports = function(grunt) {
     grunt.registerTask('build', ['nodewebkit']);
     grunt.registerTask('server', ['browserSync']);
     grunt.registerTask('run', ['shell:runApp']);
+    grunt.registerTask('debug', ['shell:runAppDebug'])
 
 }


### PR DESCRIPTION
Creates a `grunt debug` command which exposes remote debugging at port 9222.
This is I think a preferable way to debug. This also allows the app to debug it's self, really cool!! 

I am not sure that maintaing browser compatibility is worth the hassle, especially considering the node features needed to make this a fully fledged text editor (which I think is the real killer feature).


   